### PR TITLE
Bug wrong total calculation

### DIFF
--- a/Classes/Invoice.php
+++ b/Classes/Invoice.php
@@ -180,8 +180,6 @@ class Invoice
      */
     public function addItem($name, $price, $ammount = 1, $id = '-')
     {
-        $price = number_format($price, $this->decimals);
-
         $this->items->push(Collection::make([
             'name'       => $name,
             'price'      => $price,


### PR DESCRIPTION
I had an Invoice Item with a price of 9800. When I added the item, the price was

$price = number_format(9800, $this->decimals); //return 9,800.00 

And thus, when bcmul is used to calculate the totalPrice it returned 0