### PR TITLE
Add default value for the new custom template

### DIFF
--- a/Classes/Invoice.php
+++ b/Classes/Invoice.php
@@ -305,7 +305,7 @@ class Invoice
      *
      * @return self
      */
-    private function generate($template = null)
+    private function generate($template = 'vendor.invoices.default')
     {
         $this->pdf = PDF::generate($this, $template);
 
@@ -321,7 +321,7 @@ class Invoice
      *
      * @return response
      */
-    public function download($name = 'invoice', $template = null)
+    public function download($name = 'invoice', $template = 'vendor.invoices.default')
     {
         $this->generate($template);
 
@@ -336,7 +336,7 @@ class Invoice
      * @param string $name
      *
      */
-    public function save($name = 'invoice.pdf', $template = null)
+    public function save($name = 'invoice.pdf', $template = 'vendor.invoices.default')
     {
         $invoice = $this->generate($template);
 
@@ -352,7 +352,7 @@ class Invoice
      *
      * @return response
      */
-    public function show($name = 'invoice', $template = null)
+    public function show($name = 'invoice', $template = 'vendor.invoices.default')
     {
         $this->generate($template);
 


### PR DESCRIPTION
The addition of that template variable to specify a custom template broke PDF generation for anyone who already had this package in use, since we didn't expect to have to specify a template. 

![image](https://user-images.githubusercontent.com/260253/38110872-e1afa0be-3351-11e8-99f1-446c6933bac5.png)


This PR seeks to set a sensible default for that variable based on the previously recommend location of the default invoices template.