### PR TITLE
Adding the due date on invoices

### DIFF
--- a/Classes/Invoice.php
+++ b/Classes/Invoice.php
@@ -130,6 +130,13 @@ class Invoice
     public $footnote;
 
     /**
+     * Invoice Due Date.
+     *
+     * @var Carbon\Carbon
+     */
+    public $due_date = null;
+
+    /**
      * Stores the PDF object.
      *
      * @var Dompdf\Dompdf
@@ -158,6 +165,7 @@ class Invoice
         $this->business_details = Collection::make(config('invoices.business_details'));
         $this->customer_details = Collection::make([]);
         $this->footnote = config('invoices.footnote');
+        $this->due_date = config('invoices.due_date') != null ? Carbon::parse(config('invoices.due_date')) : null;
     }
 
     /**

--- a/Config/invoices.php
+++ b/Config/invoices.php
@@ -101,4 +101,16 @@ return [
 
   'footnote' => '',
 
+  /*
+  |--------------------------------------------------------------------------
+  | Default Invoice Due Date
+  |--------------------------------------------------------------------------
+  |
+  | This value is the default due date that is going to be used in invoices.
+  | You can change it on each invoice individually.
+  | You can set it null to remove the due date on all invoices.
+  */
+
+  'due_date' => date('M dS ,Y',strtotime('+3 months')),
+
 ];

--- a/Templates/default.blade.php
+++ b/Templates/default.blade.php
@@ -15,6 +15,9 @@
             </div>
             <div style="margin-left:300pt;">
                 <b>Date: </b> {{ $invoice->date->formatLocalized('%A %d %B %Y') }}<br />
+                @if ($invoice->due_date)
+                    <b>Due date: </b>{{ $invoice->due_date->formatLocalized('%A %d %B %Y') }}<br />
+                @endif
                 @if ($invoice->number)
                     <b>Invoice #: </b> {{ $invoice->number }}
                 @endif

--- a/Traits/Setters.php
+++ b/Traits/Setters.php
@@ -211,4 +211,20 @@ trait Setters
 
         return $this;
     }
+
+    /**
+     * Set the invoice due date.
+     *
+     * @method due_date
+     *
+     * @param Carbon $due_date
+     *
+     * @return self
+     */
+    public function due_date(Carbon $due_date = null)
+    {
+        $this->due_date = $due_date;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The due date can be editable on each invoice.
The due date can be set to null, so no due date appears on invoice.
The default due date is set to 3 months.