### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "ext-bcmath": "*",
-        "laravel/framework": "^9,0",
+        "laravel/framework": "^9.0",
         "nesbot/carbon": ">1.22",
         "dompdf/dompdf": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     ],
     "require": {
         "ext-bcmath": "*",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9,0",
-        "illuminate/view": "^5.0|^6.0|^7.0|^8.0|^9,0",
+        "laravel/framework": "^9,0",
         "nesbot/carbon": ">1.22",
         "dompdf/dompdf": "^1.0"
     },


### PR DESCRIPTION
Add support for Laravel 9 and removes explicit dependency on illuminate packages which were replaced by `laravel/framework`. 

Should be a major version bump to avoid issues with older versions